### PR TITLE
Added name to metadata

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "chocolatey"
 maintainer       "Guilhem Lettron"
 maintainer_email "guilhem.lettron@youscribe.com"
 license          "Apache 2.0"


### PR DESCRIPTION
Added name.  Berkshelf currently requires names for uploading to a private chef server
