### PR TITLE
Updates uri to point to latest script on chocolatey.org

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,5 @@
 if node['platform_family'] == "windows"
-  default['chocolatey']['Uri']      = "https://raw.github.com/chocolatey/chocolatey/master/chocolateyInstall/InstallChocolatey.ps1"
+  default['chocolatey']['Uri']      = "https://chocolatey.org/install.ps1"
   default['chocolatey']['path']     = ::File.join( ENV['SYSTEMDRIVE'], "Chocolatey")
   default['chocolatey']['bin_path'] = ::File.join( node['chocolatey']['path'], "bin")
   default['chocolatey']['upgrade']  = true


### PR DESCRIPTION
Simply updates the script uri attribute to point to the latest version on chocolatey.org, since the existing uri is marked as deprecated.

(Failing that, releasing your latest master branch to http://community.opscode.com/cookbooks would be great.  Some of the latest PR's you've accepted would achieve the same purpose, namely : https://github.com/Youscribe/chocolatey-cookbook/commit/65de33935a9487cb157cf1e9bd08bbf1aa651340 )
