### PR TITLE
removed 'version' from logging statement in upgradeable?

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'guilhem.lettron@youscribe.com'
 license          'Apache 2.0'
 description      'Install chocolatey and packages on Windows'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.1'
+version          '0.1.0'
 
 depends 'powershell'
 supports 'windows'


### PR DESCRIPTION
upgradeable? does not take version as an argument so the statement logged after if package_installed fails with 'Cannot find a resource for version on windows ...'. 

This pull request fixes that by removing the non-existent 'version' from the logging statement.
