### PR TITLE
Switch from "execute" to "batch" resource to ensure 64-bit environment

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -57,8 +57,8 @@ end
 action :remove do
   if @current_resource.exists
     converge_by("uninstall package #{ @current_resource.package }") do
-      execute "uninstall package #{@current_resource.package}" do
-        command "#{::File.join(node['chocolatey']['bin_path'], "chocolatey.bat")} uninstall  #{@new_resource.package} #{cmd_args}"
+      batch "uninstall package #{@current_resource.package}" do
+        code "#{::File.join(node['chocolatey']['bin_path'], "chocolatey.bat")} uninstall  #{@new_resource.package} #{cmd_args}"
       end
     end
   else
@@ -126,19 +126,19 @@ def upgradeable?(name)
 end
 
 def install(name)
-  execute "install package #{name}" do
-    command "#{::File.join(node['chocolatey']['bin_path'], "chocolatey.bat")} install #{name} #{cmd_args}"
+  batch "install package #{name}" do
+    code "#{::File.join(node['chocolatey']['bin_path'], "chocolatey.bat")} install #{name} #{cmd_args}"
   end
 end
 
 def upgrade(name)
-  execute "updating #{name} to latest" do
-    command "#{::File.join(node['chocolatey']['bin_path'], "chocolatey.bat")} update #{name} #{cmd_args}"
+  batch "updating #{name} to latest" do
+    code "#{::File.join(node['chocolatey']['bin_path'], "chocolatey.bat")} update #{name} #{cmd_args}"
   end
 end
 
 def install_version(name, version)
-  execute "install package #{name} to version #{version}" do
-    command "#{::File.join(node['chocolatey']['bin_path'], "chocolatey.bat")} install #{name} -version #{version} #{cmd_args}"
+  batch "install package #{name} to version #{version}" do
+    code "#{::File.join(node['chocolatey']['bin_path'], "chocolatey.bat")} install #{name} -version #{version} #{cmd_args}"
   end
 end


### PR DESCRIPTION
I think this should fix issue #9, by forcing the use of the correct bitness of powershell, the same as you'd get by default interactively.  Otherwise 32-bit ruby will run a 32-bit command prompt/powershell on a 64-bit box and so break some packaging scripts or DISM callers.

I thought this route slightly simpler than juliandunn's suggestion to use locate_sysnative_cmd, but both perform the same job.  Neither can help when using Mixlib::ShellOut to get the stdout from a chocolatey call, but as that's only ever used for querying versions and not doing actual installs/uninstalls, I think we're safe.