### PR TITLE
Allow spaces in the path to the "choco" command.

### DIFF
--- a/libraries/chocolatey_helpers.rb
+++ b/libraries/chocolatey_helpers.rb
@@ -9,7 +9,7 @@ module ChocolateyHelpers
   #
   # Reference: https://github.com/chocolatey/chocolatey-cookbook/pull/16#issuecomment-47975896
   def self.chocolatey_executable
-    ::File.join(chocolatey_install, 'bin', 'choco')
+    "\"#{::File.join(chocolatey_install, 'bin', 'choco')}\""
   end
 
   # Check if Chocolatey is installed


### PR DESCRIPTION
The default directory where Chocolatey installs changed to be "CommonApplicationData". On new versions of Windows this is "C:\ProgramData", on older versions of Windows (XP, 2003) this is "C:\Documents and Settings\All Users\Application Data".

Although this probably only affects users of older versions of Windows (ie people who don't change the default installation path). It will also affect users who opt to install to a different location.
