### PR TITLE
Move upgradeable check to :upgrade action knocking ~10s off each LWRP call

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -33,7 +33,6 @@ def load_current_resource
   @current_resource.options(@new_resource.options)
   @current_resource.package(@new_resource.package)
   @current_resource.exists = true if package_exists?(@current_resource.package, @current_resource.version)
-  @current_resource.upgradeable = true if upgradeable?(@current_resource.package)
   #  @current_resource.installed = true if package_installed?(@current_resource.package)
 end
 
@@ -48,7 +47,7 @@ action :install do
 end
 
 action :upgrade do
-  if @current_resource.upgradeable
+  if upgradeable?(@current_resource.package)
     upgrade(@current_resource.package)
   else
     Chef::Log.info("Package #{@current_resource} already to latest version")


### PR DESCRIPTION
After some analysis on our systems we found that each chocolatey LWRP call with the default action of :install was taking close to 20s.  By moving the upgradeable check the upgrade action we reduced this to 3-4s.  For users with even a handful of chocolatey packages this change considerably reduces the chocolatey runtime.
