### PR TITLE
Add some unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
-cookbooks
 nuget.exe
-spec
 Cheffile
 build.cmd
 build.ps1
@@ -13,7 +11,6 @@ Berksfile.lock
 \#*#
 .*.sw[a-z]
 *.un~
-/cookbooks
 
 # Bundler
 Gemfile.lock

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,7 @@
 source 'https://supermarket.getchef.com'
 
 metadata
+
+group :integration do
+  cookbook 'chocolatey_test', path: 'test/fixtures/cookbooks/chocolatey_test'
+end

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,3 @@
-source 'https://api.berkshelf.com'
+source 'https://supermarket.getchef.com'
 
 metadata

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'stove'
 group :test do
   gem 'foodcritic', '~> 4.0.0'
   gem 'rubocop', '~> 0.24.1'
+  gem 'chefspec', '~> 4.1.0'
 end
 
 group :integration do

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,7 @@
 #!/usr/bin/env rake
 
+require 'rspec/core/rake_task'
+
 # Style tests. Rubocop and Foodcritic
 namespace :style do
   begin
@@ -31,6 +33,12 @@ task style: ['style:chef', 'style:ruby']
 namespace :maintain do
   require 'stove/rake_task'
   Stove::RakeTask.new
+end
+
+namespace :test do
+  RSpec::Core::RakeTask.new(:unit) do |t|
+    t.pattern = 'spec/**/*_spec.rb'
+  end
 end
 
 desc 'Run all tests on Travis'

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,0 +1,13 @@
+if defined?(ChefSpec)
+  def install_chocolatey_package(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:chocolatey, :install, resource_name)
+  end
+
+  def upgrade_chocolatey_package(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:chocolatey, :upgrade, resource_name)
+  end
+
+  def remove_chocolatey_package(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:chocolatey, :remove, resource_name)
+  end
+end

--- a/spec/providers/default_spec.rb
+++ b/spec/providers/default_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+describe 'chocolatey_test::install_package' do
+  context 'on a supported OS' do
+    let(:chef_run) {
+      ChefSpec::SoloRunner.new(
+        platform: 'windows',
+        version: '2012',
+        step_into: 'chocolatey'
+      ).converge(described_recipe)
+    }
+
+    it 'installs package' do
+      expect(chef_run).to run_execute('install package test-package').with(command: /[^\"].+\/bin\/choco\" install test-package/)
+    end
+  end
+end
+
+describe 'chocolatey_test::remove_package' do
+  context 'on a supported OS' do
+    let(:chef_run) {
+      ChefSpec::SoloRunner.new(
+        platform: 'windows',
+        version: '2012',
+        step_into: 'chocolatey'
+      )
+    }
+
+    it 'removes package' do
+      chef_run.converge(described_recipe) do
+        allow(ChocolateyHelpers).to receive(:package_installed?).and_return(true)
+        allow(ChocolateyHelpers).to receive(:package_exists?).and_return(true)
+      end
+      expect(chef_run).to run_execute('uninstall package test-package').with(command: /[^\"].+\/bin\/choco\" uninstall test-package/)
+    end
+  end
+end
+
+describe 'chocolatey_test::upgrade_package' do
+  context 'on a supported OS' do
+    let(:chef_run) {
+      ChefSpec::SoloRunner.new(
+        platform: 'windows',
+        version: '2012',
+        step_into: 'chocolatey'
+      )
+    }
+
+    it 'upgrades package' do
+      chef_run.converge(described_recipe) do
+        allow(ChocolateyHelpers).to receive(:upgradeable?).and_return(true)
+      end
+      expect(chef_run).to run_execute('updating test-package to latest').with(command: /[^\"].+\/bin\/choco\" update test-package/)
+    end
+  end
+end

--- a/spec/recipes/default_spec.rb
+++ b/spec/recipes/default_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe 'chocolatey::default' do
+  context 'on a supported OS' do
+    let(:chef_run) {
+      ChefSpec::SoloRunner.new(platform: 'windows', version: '2012')
+    }
+
+    it 'installs chocolatey if not already installed' do
+      chef_run.converge(described_recipe) do
+        allow(ChocolateyHelpers).to receive(:chocolatey_installed?).and_return(false)
+      end
+      expect(chef_run).to run_powershell_script('install chocolatey')
+    end
+
+    it 'does not install chocolatey if already installed' do
+      chef_run.converge(described_recipe) do
+        allow(ChocolateyHelpers).to receive(:chocolatey_installed?).and_return(true)
+      end
+      expect(chef_run).to_not run_powershell_script('install chocolatey')
+    end
+
+    it 'upgrades chocolatey' do
+      chef_run.converge(described_recipe)
+      expect(chef_run).to upgrade_chocolatey_package('chocolatey')
+    end
+  end
+
+  context 'on an unsupported OS' do
+    let(:chef_run) {
+      ChefSpec::SoloRunner.new(platform: 'debian', version: '7.6').converge(described_recipe)
+    }
+
+    it 'does not install chocolatey' do
+      chef_run.converge(described_recipe)
+      expect(chef_run).to_not include_recipe('windows')
+      expect(chef_run).to_not run_powershell_script('install chocolatey')
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,4 @@
+require 'chefspec'
+require 'chefspec/berkshelf'
+
+require '../libraries/chocolatey_helpers.rb'

--- a/test/fixtures/cookbooks/chocolatey_test/README.md
+++ b/test/fixtures/cookbooks/chocolatey_test/README.md
@@ -1,0 +1,4 @@
+Test Chocolatey Cookbook
+========================
+
+Test cookbook for testing the chocolatey cookbook with ChefSpec.

--- a/test/fixtures/cookbooks/chocolatey_test/metadata.rb
+++ b/test/fixtures/cookbooks/chocolatey_test/metadata.rb
@@ -1,0 +1,9 @@
+name             'chocolatey_test'
+maintainer       'Guilhem Lettron'
+maintainer_email 'guilhem.lettron@youscribe.com'
+license          'Apache 2.0'
+description      'Test cookbook for Chocolatey'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version          '0.0.1'
+
+depends 'chocolatey'

--- a/test/fixtures/cookbooks/chocolatey_test/recipes/install_package.rb
+++ b/test/fixtures/cookbooks/chocolatey_test/recipes/install_package.rb
@@ -1,0 +1,1 @@
+chocolatey 'test-package'

--- a/test/fixtures/cookbooks/chocolatey_test/recipes/remove_package.rb
+++ b/test/fixtures/cookbooks/chocolatey_test/recipes/remove_package.rb
@@ -1,0 +1,3 @@
+chocolatey 'test-package' do
+  action :remove
+end

--- a/test/fixtures/cookbooks/chocolatey_test/recipes/upgrade_package.rb
+++ b/test/fixtures/cookbooks/chocolatey_test/recipes/upgrade_package.rb
@@ -1,0 +1,3 @@
+chocolatey 'test-package' do
+  action :upgrade
+end


### PR DESCRIPTION
I wanted to do some larger refactorings, but felt uncomfortable without some existing test coverage so I tried to add some ChefSpec tests around this cookbook—the coverage is by no means complete but I'm hoping it's a good start. You should be able to invoke the tests with `rake test:unit`.

You might have to do something like [this](https://github.com/opscode/chef-dk/issues/106#issuecomment-50245127) if you have issues with Faraday and SSL.

I'm hoping to do more work refactoring. However, I figured those changes might be objectionable and I think the value of these tests hopefully stand by themselves.

I moved a bunch of methods from default provider into the helper module to make substituting test doubles easier, hope that's okay.