### PR TITLE
The package name should be case insensitive

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -92,11 +92,11 @@ def package_exists?(name, version)
   cmd.run_command
   software = cmd.stdout.split("\r\n").each_with_object({}) do |s, h|
     v, k = s.split
-    h[String(v).strip] = String(k).strip
+    h[String(v).strip.downcase] = String(k).strip
     h
   end
 
-  software[name] == version
+  software[name.downcase] == version
 end
 
 def upgradeable?(name)

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -92,11 +92,11 @@ def package_exists?(name, version)
   cmd.run_command
   software = cmd.stdout.split("\r\n").each_with_object({}) do |s, h|
     v, k = s.split
-    h[String(v).strip.downcase] = String(k).strip
+    h[String(v).strip.downcase] = String(k).strip.downcase
     h
   end
 
-  software[name.downcase] == version
+  software[name.downcase] == version.downcase
 end
 
 def upgradeable?(name)


### PR DESCRIPTION
An example that is always updated (without this patch):
```ruby
chocolatey 'conemu'
```