### PR TITLE
fix for 64-bit chocolatey installs

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -24,10 +24,21 @@ include_recipe 'windows'
 # ::Chef::Recipe.send(:include, Chef::Mixin::PowershellOut)
 ::Chef::Resource::RubyBlock.send(:include, Chef::Mixin::PowershellOut)
 
-powershell_script 'install chocolatey' do
-  code "iex ((new-object net.webclient).DownloadString('#{node['chocolatey']['Uri']}'))"
-  convert_boolean_return true
-  not_if { ChocolateyHelpers.chocolatey_installed? }
+if File.exist?('C:\windows\system32\cmd.exe')
+  arch = :x86_64
+  cmd = 'C:\windows\system32\cmd.exe'
+else
+  arch = nil
+  cmd = 'cmd.exe'
+end
+
+batch 'install chocolatey' do
+  architecture arch
+  interpreter cmd
+  code <<-EOH
+    powershell -noprofile -inputformat none -noninteractive -executionpolicy bypass -command "iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))"
+  EOH
+  not_if "test-path '#{chocolatey_path}\\choco.exe'"
 end
 
 ruby_block "reset ENV['ChocolateyInstall']" do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -38,7 +38,7 @@ batch 'install chocolatey' do
   code <<-EOH
     powershell -noprofile -inputformat none -noninteractive -executionpolicy bypass -command "iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))"
   EOH
-  not_if "test-path '#{chocolatey_path}\\choco.exe'"
+  not_if { ChocolateyHelpers.chocolatey_installed? }
 end
 
 ruby_block "reset ENV['ChocolateyInstall']" do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -24,9 +24,9 @@ include_recipe 'windows'
 # ::Chef::Recipe.send(:include, Chef::Mixin::PowershellOut)
 ::Chef::Resource::RubyBlock.send(:include, Chef::Mixin::PowershellOut)
 
-if File.exist?('C:\windows\system32\cmd.exe')
+if File.exist?('C:\windows\sysnative\cmd.exe')
   arch = :x86_64
-  cmd = 'C:\windows\system32\cmd.exe'
+  cmd = 'C:\windows\sysnative\cmd.exe'
 else
   arch = nil
   cmd = 'cmd.exe'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -36,7 +36,7 @@ batch 'install chocolatey' do
   architecture arch
   interpreter cmd
   code <<-EOH
-    powershell -noprofile -inputformat none -noninteractive -executionpolicy bypass -command "iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))"
+    powershell -noprofile -inputformat none -noninteractive -executionpolicy bypass -command "iex ((new-object net.webclient).DownloadString('#{node['chocolatey']['Uri']}'))"
   EOH
   not_if { ChocolateyHelpers.chocolatey_installed? }
 end


### PR DESCRIPTION
on 64-bit we need to invoke the install in a 64-bit environment.

we can use the interpreter flag to the chef script resource to do this.

i had a dificult time beating powershell_script into submission.  invoking cmd
to invoke powershell is a little gross, but the full path to the 64-bit
cmd.exe also looks like it'll be less brittle than the powershell path that
had the version string embedded in it.

fixes #38