### PR TITLE
Chocolatey install: add proxy support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ Gemfile.lock
 bin/*
 .bundle/*
 
+.kitchen/
+.kitchen.local.yml

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,17 @@
+---
+driver:
+  name: vagrant
+
+provisioner:
+  name: chef_solo
+
+platforms:
+  - name: win2012r2-standard
+  - name: win2008r2-standard
+
+suites:
+  - name: default
+    run_list:
+      - recipe[chocolatey::default]
+
+    attributes:

--- a/Gemfile
+++ b/Gemfile
@@ -1,15 +1,16 @@
 source 'https://rubygems.org'
 
-gem 'rake'
-gem 'berkshelf', '~> 3.1.4'
-gem 'stove'
+gem 'rake', '~> 10.4'
+gem 'berkshelf', '~> 3.2'
+gem 'stove', '~> 3.2'
 
 group :test do
-  gem 'foodcritic', '~> 4.0.0'
-  gem 'rubocop', '~> 0.24.1'
+  gem 'foodcritic', '~> 4.0'
+  gem 'rubocop', '~> 0.32'
 end
 
 group :integration do
-  gem 'test-kitchen', '~> 1.2.1'
-  gem 'kitchen-vagrant', '~> 0.15.0'
+  gem 'test-kitchen', '~> 1.4'
+  gem 'kitchen-vagrant', '~> 0.18'
+  gem 'winrm-transport'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -38,3 +38,10 @@ task travis: ['style']
 
 # Default
 task default: ['style']
+
+begin
+  require 'kitchen/rake_tasks'
+  Kitchen::RakeTasks.new
+rescue LoadError
+  puts '>>>>> Kitchen gem not loaded, omitting tasks' unless ENV['CI']
+end

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -24,7 +24,7 @@ def whyrun_supported?
   true
 end
 
-def load_current_resource
+def load_current_resource   # rubocop:disable Metrics/AbcSize
   @current_resource = Chef::Resource::Chocolatey.new(@new_resource.name)
   @current_resource.name(@new_resource.name)
   @current_resource.version(@new_resource.version)
@@ -32,13 +32,13 @@ def load_current_resource
   @current_resource.args(@new_resource.args)
   @current_resource.options(@new_resource.options)
   @current_resource.package(@new_resource.package)
-  @current_resource.exists = true if package_exists?(@current_resource.package, @current_resource.version)
+  @current_resource.exists = package_exists?(@current_resource.package, @current_resource.version)
   #  @current_resource.installed = true if package_installed?(@current_resource.package)
 end
 
 action :install do
   if @current_resource.exists
-    Chef::Log.info "#{ @current_resource.package } already installed - nothing to do."
+    Chef::Log.info "#{@current_resource.package} already installed - nothing to do."
   elsif @current_resource.version
     install_version(@current_resource.package, @current_resource.version)
   else
@@ -83,7 +83,7 @@ def package_installed?(name)
   package_exists?(name, nil)
 end
 
-def package_exists?(name, version)
+def package_exists?(name, version)   # rubocop:disable Metrics/AbcSize
   cmd = Mixlib::ShellOut.new("#{::ChocolateyHelpers.chocolatey_executable} list -l -r #{name}")
   cmd.run_command
   software = cmd.stdout.split("\r\n").each_with_object({}) do |s, h|
@@ -99,7 +99,7 @@ def package_exists?(name, version)
   end
 end
 
-def upgradeable?(name)
+def upgradeable?(name)   # rubocop:disable Metrics/AbcSize
   return false unless @current_resource.exists
   unless package_installed?(name)
     Chef::Log.debug("Package isn't installed... we can upgrade it!")

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -32,11 +32,13 @@ else
   cmd = 'cmd.exe'
 end
 
+chocolatey_install_script = "$wc = New-Object Net.WebClient; $wc.UseDefaultCredentials = $true; $wc.Proxy.Credentials = $wc.Credentials; $wc.DownloadString('#{node['chocolatey']['Uri']}')"
+
 batch 'install chocolatey' do
   architecture arch
   interpreter cmd
   code <<-EOH
-    powershell -noprofile -inputformat none -noninteractive -executionpolicy bypass -command "iex ((new-object net.webclient).DownloadString('#{node['chocolatey']['Uri']}'))"
+    powershell -noprofile -inputformat none -noninteractive -executionpolicy bypass -command "#{chocolatey_install_script} | Invoke-Expression"
   EOH
   not_if { ChocolateyHelpers.chocolatey_installed? }
 end


### PR DESCRIPTION
This adds support for installing Chocolatey from behind a proxy.
Inspired by http://powershell.com/cs/blogs/tips/archive/2010/11/12/get-webclient-with-proxy-authentication.aspx

Also added test-kitchen support for Win2012r2 and 2008R2