### PR TITLE
Use chef proxy settings

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -36,7 +36,7 @@ end
 # This also works if you are not behind a proxy
 command = <<-EOS
   if ($env:http_proxy -eq $null) {
-    $proxy=[system.net.WebProxy]::GetDefaultProxy()
+    $proxy=[system.net.WebRequest]::DefaultWebProxy()
     $proxy.UseDefaultCredentials=$true
   }
   else {

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -35,11 +35,11 @@ end
 # Add ability to download Chocolatey install script behind a proxy
 # This also works if you are not behind a proxy
 command = <<-EOS
-  $wc = New-Object Net.WebClient
-  $wp=[system.net.WebProxy]::GetDefaultProxy()
-  $wp.UseDefaultCredentials=$true
-  $wc.Proxy=$wp
-  Invoke-Expression ($wc.DownloadString('#{node['chocolatey']['Uri']}'))
+  $proxy=[system.net.WebProxy]::GetDefaultProxy()
+  $proxy.UseDefaultCredentials=$true
+  $client = New-Object Net.WebClient
+  $client.Proxy=$proxy
+  Invoke-Expression ($client.DownloadString('#{node['chocolatey']['Uri']}'))
 EOS
 
 encoded_script = command.encode('UTF-16LE', 'UTF-8')

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -35,8 +35,14 @@ end
 # Add ability to download Chocolatey install script behind a proxy
 # This also works if you are not behind a proxy
 command = <<-EOS
-  $proxy=[system.net.WebProxy]::GetDefaultProxy()
-  $proxy.UseDefaultCredentials=$true
+  if ($env:http_proxy -eq $null) {
+    $proxy=[system.net.WebProxy]::GetDefaultProxy()
+    $proxy.UseDefaultCredentials=$true
+  }
+  else {
+    $proxy = New-Object -TypeName System.Net.WebProxy
+    $proxy.Address = $env:http_proxy
+  }
   $client = New-Object Net.WebClient
   $client.Proxy=$proxy
   Invoke-Expression ($client.DownloadString('#{node['chocolatey']['Uri']}'))


### PR DESCRIPTION
Use the `http_proxy` setting from chef-client configuration, rather than the default Windows/IE proxy settings.