### PR TITLE
Install packages from attributes

### DIFF
--- a/recipes/install_packages.rb
+++ b/recipes/install_packages.rb
@@ -1,0 +1,32 @@
+#
+# Cookbook Name:: chocolatey
+# recipe:: default
+# Author:: Bob van den Heuvel
+#
+# Copyright 2015
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+return 'platform not supported' if node['platform_family'] != 'windows'
+include_recipe 'chocolatey::default'
+
+node['chocolatey']['packages'].each do |pack, settings|
+  chocolatey pack.to_s do
+    action !settings['action'].nil? ? settings['action'] : 'install'
+    args settings['args'] unless settings['args'].nil?
+    version settings['version'] unless settings['version'].nil?
+    source settings['source'] unless settings['source'].nil?
+    options settings['options'] unless settings['options'].nil?
+  end
+end


### PR DESCRIPTION
Using this recipe, with the following attributes:
```ruby
          'chocolatey' => {
            'packages' => {
              'sysinternals' =>     { 'action' => 'install' },
              '7zip' =>             { 'action' => 'install' },
              'notepadplusplus' =>  { 'action' => 'install' },
              'GoogleChrome' =>     { 'action' => 'install' },
              'wireshark' =>        { 'action' => 'install', 'version' => '1.12.6' }
            }
```
will loop over the packages and install them with the options which can be provided to the resource.
