### PR TITLE
use powershell_out! to fix break introduced with chef 12.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gem 'rake', '~> 10.4'
 gem 'berkshelf', '~> 3.2'
 gem 'stove', '~> 3.2'
+gem 'varia_model', '0.4.0'
 
 group :test do
   gem 'foodcritic', '~> 4.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'guilhem.lettron@youscribe.com'
 license          'Apache 2.0'
 description      'Install chocolatey and packages on Windows'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.4.0'
+version          '0.4.1'
 
 supports 'windows'
 

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -24,7 +24,7 @@ def whyrun_supported?
   true
 end
 
-def load_current_resource   # rubocop:disable Metrics/AbcSize
+def load_current_resource # rubocop:disable Metrics/AbcSize
   @current_resource = Chef::Resource::Chocolatey.new(@new_resource.name)
   @current_resource.name(@new_resource.name)
   @current_resource.version(@new_resource.version)
@@ -83,7 +83,7 @@ def package_installed?(name)
   package_exists?(name, nil)
 end
 
-def package_exists?(name, version)   # rubocop:disable Metrics/AbcSize
+def package_exists?(name, version) # rubocop:disable Metrics/AbcSize
   cmd = Mixlib::ShellOut.new("#{::ChocolateyHelpers.chocolatey_executable} list -l -r #{name}")
   cmd.run_command
   software = cmd.stdout.split("\r\n").each_with_object({}) do |s, h|
@@ -99,7 +99,7 @@ def package_exists?(name, version)   # rubocop:disable Metrics/AbcSize
   end
 end
 
-def upgradeable?(name)   # rubocop:disable Metrics/AbcSize
+def upgradeable?(name) # rubocop:disable Metrics/AbcSize
   return false unless @current_resource.exists
   unless package_installed?(name)
     Chef::Log.debug("Package isn't installed... we can upgrade it!")

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,10 +25,8 @@ include_recipe 'windows'
 ::Chef::Resource::RubyBlock.send(:include, Chef::Mixin::PowershellOut)
 
 if File.exist?('C:\windows\sysnative\cmd.exe')
-  arch = :x86_64
   cmd = 'C:\windows\sysnative\cmd.exe'
 else
-  arch = nil
   cmd = 'cmd.exe'
 end
 
@@ -45,8 +43,8 @@ EOS
 encoded_script = command.encode('UTF-16LE', 'UTF-8')
 chocolatey_install_script = Base64.strict_encode64(encoded_script)
 
-batch 'install chocolatey' do
-  architecture arch
+script 'install chocolatey' do
+  flags '<'
   interpreter cmd
   code <<-EOH
     powershell -noprofile -inputformat none -noninteractive -executionpolicy bypass -EncodedCommand #{chocolatey_install_script}


### PR DESCRIPTION
This fixes #54 introduced by [this chef issue](https://github.com/chef/chef/issues/4057). The `script` resource is 2 levels up the inheritance chain from `batch` and it does not include the new interpreter path logic introduced in chef 12.5. The only thing it misses that is needed in the batch resource for installing chocolatey is that it does not appent the `.bat` file extension to the script file. This PR gets arounc that by passing the file to `cmd`'s stdin to execute the script.