### PR TITLE
Add track_path option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog for Chocolatey cookbook
 
+### v0.5.2 (2015-11-14)
+
+* Ability to track_path, merging changes made by packages to user and machine
+  %PATH% environment into the current process
+
 ### v0.5.1 (2015-11-10)
 
 * Prepend library include with :: in provder to fix 12.3.0 and likely other versions older than 12.5.1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,7 @@
 ### v0.5.2 (2015-11-14)
 
 * Path Tracking. Tracking additions to the user and machine
-  %PATH% environment and merging them into the current process. To get the old
-  behaviour add a `track_path false` attribute to the chocolatey resource
+  %PATH% environment and merging them into the current process. 
 
 ### v0.5.1 (2015-11-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ### v0.5.2 (2015-11-14)
 
-* Ability to track_path, merging changes made by packages to user and machine
-  %PATH% environment into the current process
+* Path Tracking. Tracking additions to the user and machine
+  %PATH% environment and merging them into the current process. To get the old
+  behaviour add a `track_path false` attribute to the chocolatey resource
 
 ### v0.5.1 (2015-11-10)
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Attribute | Description | Type   | Default
 - version: The version of the package to use.
 - args: arguments to the installation.
 - options: Hash of additional options to be sent to `choco.exe`
+- track_path: Track changes to the %PATH% made by the package
 
 # Examples
 
@@ -76,6 +77,11 @@ end
   chocolatey pack do
     source 'cygwin'
   end
+end
+
+chocolatey 'git.install' do
+    options ({ 'params' => "'/GitOnlyOnPath'" })
+    track_path true
 end
 
 chocolatey 'wireshark' do

--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ Attribute | Description | Type   | Default
 - version: The version of the package to use.
 - args: arguments to the installation.
 - options: Hash of additional options to be sent to `choco.exe`
-- track_path: Track changes to the %PATH% made by the package (default true)
 
 # Examples
 
@@ -81,7 +80,6 @@ end
 
 chocolatey 'git.install' do
     options ({ 'params' => "'/GitOnlyOnPath'" })
-    track_path true
 end
 
 chocolatey 'wireshark' do

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Attribute | Description | Type   | Default
 - version: The version of the package to use.
 - args: arguments to the installation.
 - options: Hash of additional options to be sent to `choco.exe`
-- track_path: Track changes to the %PATH% made by the package
+- track_path: Track changes to the %PATH% made by the package (default true)
 
 # Examples
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -44,7 +44,7 @@ module Chocolatey
       machine  = env_var('PATH', 'MACHINE').split(';')
       user     = env_var('PATH', 'USER').split(';')
       local    = local_path.split(';')
-      combined = local.concat(user).concat(machine).uniq.compact
+      combined = local.concat(machine).concat(user).uniq.compact
       combined.join(';')
     end
   end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -47,6 +47,5 @@ module Chocolatey
       combined = local.concat(user).concat(machine).uniq.compact
       combined.join(';')
     end
-
   end
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -29,10 +29,25 @@ module Chocolatey
     private
 
     def machine_env_var(env_var)
+        env_var(env_var, 'MACHINE')
+    end
+
+    def env_var(env_var, scope)
       env_var = powershell_out!(
-        "[System.Environment]::GetEnvironmentVariable('#{env_var}', 'MACHINE')"
+        "[System.Environment]::GetEnvironmentVariable('#{env_var}', '#{scope}')"
       )
       env_var.stdout.chomp
     end
+
+    # combine the local path with the user and machine paths
+    def env_path(local_path)
+        machine  = env_var('PATH', 'MACHINE').split(';')
+        user     = env_var('PATH', 'USER').split(';')
+        local    = local_path.split(';')
+        combined = local.concat(user).concat(machine).uniq().compact()
+        return combined.join(';')
+    end
+
+
   end
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -29,7 +29,7 @@ module Chocolatey
     private
 
     def machine_env_var(env_var)
-        env_var(env_var, 'MACHINE')
+      env_var(env_var, 'MACHINE')
     end
 
     def env_var(env_var, scope)
@@ -41,13 +41,12 @@ module Chocolatey
 
     # combine the local path with the user and machine paths
     def env_path(local_path)
-        machine  = env_var('PATH', 'MACHINE').split(';')
-        user     = env_var('PATH', 'USER').split(';')
-        local    = local_path.split(';')
-        combined = local.concat(user).concat(machine).uniq().compact()
-        return combined.join(';')
+      machine  = env_var('PATH', 'MACHINE').split(';')
+      user     = env_var('PATH', 'USER').split(';')
+      local    = local_path.split(';')
+      combined = local.concat(user).concat(machine).uniq.compact
+      combined.join(';')
     end
-
 
   end
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'guilhem.lettron@youscribe.com'
 license          'Apache 2.0'
 description      'Install chocolatey and packages on Windows'
 long_description 'Installs the Chocolatey package manager for Windows and provides a Chef resource for installing nuget packages from https://chocolatey.org/'
-version          '0.5.1'
+version          '0.5.2'
 
 source_url 'https://github.com/chocolatey/chocolatey-cookbook' if defined?(:source_url)
 issues_url 'https://github.com/chocolatey/chocolatey-cookbook/issues' if defined?(:issues_url)

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -35,6 +35,7 @@ def load_current_resource # rubocop:disable Metrics/AbcSize
   @current_resource.args(@new_resource.args)
   @current_resource.options(@new_resource.options)
   @current_resource.package(@new_resource.package)
+  @current_resource.track_path(@new_resource.track_path)
   @current_resource.exists = package_exists?(@current_resource.package, @current_resource.version)
   #  @current_resource.installed = true if package_installed?(@current_resource.package)
 end
@@ -42,11 +43,22 @@ end
 action :install do
   if @current_resource.exists
     Chef::Log.info "#{@current_resource.package} already installed - nothing to do."
-  elsif @current_resource.version
+    return
+  end
+  if @current_resource.version
     install_version(@current_resource.package, @current_resource.version)
   else
     install(@current_resource.package)
   end
+  if @current_resource.track_path
+      adjust_path(@current_resource.package)
+  end
+end
+
+def adjust_path(name)
+ ruby_block  "adj-path-#{name}" do
+   block { ENV['PATH'] = env_path(ENV['PATH']) }
+ end
 end
 
 action :upgrade do

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -35,7 +35,6 @@ def load_current_resource # rubocop:disable Metrics/AbcSize
   @current_resource.args(@new_resource.args)
   @current_resource.options(@new_resource.options)
   @current_resource.package(@new_resource.package)
-  @current_resource.track_path(@new_resource.track_path)
   @current_resource.exists = package_exists?(@current_resource.package, @current_resource.version)
   #  @current_resource.installed = true if package_installed?(@current_resource.package)
 end
@@ -50,7 +49,7 @@ action :install do
   else
     install(@current_resource.package)
   end
-  @current_resource.track_path && adjust_path(@current_resource.package)
+  adjust_path(@current_resource.package)
 end
 
 def adjust_path(name)

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -50,15 +50,13 @@ action :install do
   else
     install(@current_resource.package)
   end
-  if @current_resource.track_path
-      adjust_path(@current_resource.package)
-  end
+  @current_resource.track_path && adjust_path(@current_resource.package)
 end
 
 def adjust_path(name)
- ruby_block  "adj-path-#{name}" do
-   block { ENV['PATH'] = env_path(ENV['PATH']) }
- end
+  ruby_block "track-path-#{name}" do
+    block { ENV['PATH'] = env_path(ENV['PATH']) }
+  end
 end
 
 action :upgrade do

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -5,7 +5,6 @@ attribute :source, :kind_of => String
 attribute :version, :kind_of => String
 attribute :args, :kind_of => String
 attribute :options, :kind_of => Hash, :default => {}
-attribute :track_path, :kind_of => [TrueClass, FalseClass], :default => true
 
 def initialize(*args)
   super

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -5,6 +5,7 @@ attribute :source, :kind_of => String
 attribute :version, :kind_of => String
 attribute :args, :kind_of => String
 attribute :options, :kind_of => Hash, :default => {}
+attribute :track_path, :kind_of => [TrueClass, FalseClass], :default => false
 
 def initialize(*args)
   super

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -5,7 +5,7 @@ attribute :source, :kind_of => String
 attribute :version, :kind_of => String
 attribute :args, :kind_of => String
 attribute :options, :kind_of => Hash, :default => {}
-attribute :track_path, :kind_of => [TrueClass, FalseClass], :default => false
+attribute :track_path, :kind_of => [TrueClass, FalseClass], :default => true
 
 def initialize(*args)
   super


### PR DESCRIPTION
An approach to: https://github.com/chocolatey/chocolatey-cookbook/issues/67

Added an attribute to the chocolatey resource to update the `ENV['PATH']` during the chef install run so that choc packages that make changes to the path can be run in the same recipe as those that depend on the path reflecting the changes.



