### PR TITLE
removed deprecated overwriting of the current_resource and fixed a function visibility problem in the helper

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ AllCops:
   Exclude:
     - vendor/**
 
-SingleSpaceBeforeFirstArg:
+SpaceBeforeFirstArg:
   Exclude:
     - metadata.rb
 ClassLength:
@@ -25,7 +25,7 @@ MethodLength:
   Enabled: false
 SignalException:
   Enabled: false
-TrailingComma:
+TrailingCommaInLiteral:
   Enabled: false
 WordArray:
   Enabled: false

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -30,6 +30,15 @@ module Chocolatey
       @is_chocolatey_installed = (cmd.exitstatus == 0)
     end
 
+    # combine the local path with the user and machine paths
+    def env_path(local_path)
+      machine  = env_var('PATH', 'MACHINE').split(';')
+      user     = env_var('PATH', 'USER').split(';')
+      local    = local_path.split(';')
+      combined = local.concat(machine).concat(user).uniq.compact
+      combined.join(';')
+    end
+
     private
 
     def machine_env_var(env_var)
@@ -41,15 +50,6 @@ module Chocolatey
         "[System.Environment]::GetEnvironmentVariable('#{env_var}', '#{scope}')"
       )
       env_var.stdout.chomp
-    end
-
-    # combine the local path with the user and machine paths
-    def env_path(local_path)
-      machine  = env_var('PATH', 'MACHINE').split(';')
-      user     = env_var('PATH', 'USER').split(';')
-      local    = local_path.split(';')
-      combined = local.concat(machine).concat(user).uniq.compact
-      combined.join(';')
     end
   end
 end

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -31,8 +31,8 @@ def load_current_resource # rubocop:disable Metrics/AbcSize
   @current_resource = Chef::Resource::Chocolatey.new(@new_resource.name)
   @current_resource.name(@new_resource.name)
   @current_resource.version(@new_resource.version)
-  @current_resource.source(@new_resource.source)
-  @current_resource.args(@new_resource.args)
+  @current_resource.source(@new_resource.source) unless @new_resource.source.nil?
+  @current_resource.args(@new_resource.args) unless @new_resource.args.nil?
   @current_resource.options(@new_resource.options)
   @current_resource.package(@new_resource.package)
   @current_resource.exists = package_exists?(@current_resource.package, @current_resource.version)

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -105,7 +105,7 @@ def package_exists?(name, version) # rubocop:disable Metrics/AbcSize
   end
 
   if version
-    software[name.downcase] == version.downcase
+    software[name.downcase].casecmp(version.downcase)
   else
     !software[name.downcase].nil?
   end

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -1,10 +1,10 @@
 actions :install, :remove, :upgrade
 
-attribute :package, :kind_of => String, :name_attribute => true
-attribute :source, :kind_of => String
-attribute :version, :kind_of => String
-attribute :args, :kind_of => String
-attribute :options, :kind_of => Hash, :default => {}
+attribute :package, kind_of: String, name_attribute: true
+attribute :source, kind_of: [String, nil], default: nil
+attribute :version, kind_of: [String]
+attribute :args, kind_of: [String, nil], default: nil
+attribute :options, kind_of: Hash, default: {}
 
 def initialize(*args)
   super

--- a/test/cookbooks/chocolatey_test/recipes/default.rb
+++ b/test/cookbooks/chocolatey_test/recipes/default.rb
@@ -1,5 +1,5 @@
 chocolatey 'git.install' do
-  options('params' =>  "'/GitOnlyOnPath'")
+  options('params' => "'/GitOnlyOnPath'")
 end
 
 git File.join(ENV['TEMP'], 'chocolatey-cookbook') do


### PR DESCRIPTION
I moved the helper function env_path into the public scope because it is used by the provider. Further it will not be supported anymore in chef 13 to overwrite current_resource with nil values. This change will prevent that.