### PR TITLE
Fix nil reference when a package version is specified

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'guilhem.lettron@youscribe.com'
 license          'Apache 2.0'
 description      'Install chocolatey and packages on Windows'
 long_description 'Installs the Chocolatey package manager for Windows and provides a Chef resource for installing nuget packages from https://chocolatey.org/'
-version          '0.6.2'
+version          '0.6.3'
 
 source_url 'https://github.com/chocolatey/chocolatey-cookbook' if defined?(:source_url)
 issues_url 'https://github.com/chocolatey/chocolatey-cookbook/issues' if defined?(:issues_url)

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -105,7 +105,8 @@ def package_exists?(name, version) # rubocop:disable Metrics/AbcSize
   end
 
   if version
-    software[name.downcase].casecmp(version.downcase)
+    installed = software[name.downcase]
+    installed && installed.downcase.casecmp(version.downcase) == 0
   else
     !software[name.downcase].nil?
   end


### PR DESCRIPTION
Return false from `package_exists?` if the package is not installed OR the version installed does not match the requested one.

Old logic tried to downcase a nil if there was no package installed on the target machine but a specific version was requested.

