### PR TITLE
Removing ruby 2.0 travis suite and moving integration tests to inspec

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -10,6 +10,9 @@ platforms:
   driver_config:
     box: mwrock/Windows2012R2
 
+verifier:
+  name: inspec
+
 suites:
   - name: default
     run_list:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: ruby
 bundler_args: --without integration
 rvm:
-  - 2.0
   - 2.1
 script: bundle exec rake
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ end
 
 group :integration do
   gem 'kitchen-vagrant', '~> 0.19'
-  gem 'serverspec', '~> 2.24'
+  gem 'kitchen-inspec', '~> 0.14'
   gem 'test-kitchen', '~> 1.6'
-  gem 'winrm-fs', '~> 0.3'
+  gem 'winrm-fs', '~> 0.4'
 end

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -1,26 +1,24 @@
-require 'spec_helper'
-
 choco_exe = File.join(ENV['ProgramData'], 'chocolatey', 'bin', 'choco.exe')
 chocolatey_nupkg = File.join(
   ENV['ProgramData'], 'chocolatey', 'lib', 'chocolatey', 'chocolatey.nupkg'
 )
 
-RSpec.describe command(choco_exe) do
+describe command(choco_exe) do
   its(:stdout) { should match(/Chocolatey/) }
 end
 
-RSpec.describe command("#{choco_exe} list -l chocolatey") do
+describe command("#{choco_exe} list -l chocolatey") do
   its(:stdout) { should match(/[1-9] packages installed\./) }
 end
 
-RSpec.describe command("#{choco_exe} list -l git.install") do
+describe command("#{choco_exe} list -l git.install") do
   its(:stdout) { should match(/1 packages installed\./) }
 end
 
-RSpec.describe file(chocolatey_nupkg) do
+describe file(chocolatey_nupkg) do
   it { should exist }
 end
 
-RSpec.describe file(File.join(ENV['TEMP'], 'chocolatey-cookbook', 'metadata.rb')) do
+describe file(File.join('$env:temp', 'chocolatey-cookbook', 'metadata.rb')) do
   it { should exist }
 end

--- a/test/integration/default/serverspec/spec_helper.rb
+++ b/test/integration/default/serverspec/spec_helper.rb
@@ -1,4 +1,0 @@
-require 'serverspec'
-
-set :backend, :cmd
-set :os, family: 'windows'


### PR DESCRIPTION
ruby 2.0 is dead to us. Also ran into ugly winrm issues on appveyor due to wmf5 issue with progress stream leaking to stderr. Moving to inspec and also released winrm-fs 0.4.3 fixes that.