### PR TITLE
fixes #88 Always execute chocolatey installer unless guard is satisfied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for Chocolatey cookbook
 
+### v1.0.1 (2016-07-15)
+
+* Always execute chocolatey installer unless guard is satisfied to allow the install to retry on subsequent attempts if it fails.
+
 ### v1.0.0 (2016-03-07)
 
 * No longer dependent on chocolatey.org for install script

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'guilhem.lettron@youscribe.com'
 license          'Apache 2.0'
 description      'Install chocolatey and packages on Windows'
 long_description 'Installs the Chocolatey package manager for Windows and provides a Chef resource for installing nuget packages from https://chocolatey.org/'
-version          '1.0.0'
+version          '1.0.1'
 
 source_url 'https://github.com/chocolatey/chocolatey-cookbook' if defined?(:source_url)
 issues_url 'https://github.com/chocolatey/chocolatey-cookbook/issues' if defined?(:issues_url)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -31,13 +31,11 @@ template install_ps1 do
   backup false
   source 'InstallChocolatey.ps1.erb'
   variables :download_url => node['chocolatey']['install_vars']['chocolateyDownloadUrl']
-  notifies :run, 'powershell_script[Install Chocolatey]', :immediately
-  not_if { chocolatey_installed? && (node['chocolatey']['upgrade'] == false) }
 end
 
 powershell_script 'Install Chocolatey' do
-  action :nothing
   environment node['chocolatey']['install_vars']
   cwd Chef::Config['file_cache_path']
   code install_ps1
+  not_if { chocolatey_installed? && (node['chocolatey']['upgrade'] == false) }
 end

--- a/spec/recipes/default_spec.rb
+++ b/spec/recipes/default_spec.rb
@@ -42,14 +42,6 @@ RSpec.describe 'chocolatey::default' do
       )
     end
 
-    it 'install.ps1 template notifies powershell_script to run the Chocolatey install script' do
-      expect(install_template).to notify('powershell_script[Install Chocolatey]').to(:run).immediately
-    end
-
-    it 'powershell_script does not install Chocolatey unless a new install.ps1 has been downloaded' do
-      expect(powershell_script).to do_nothing
-    end
-
     it 'powershell_script does not set chocolateyProxyLocation' do
       expect(powershell_script.environment['chocolateyProxyLocation']).to eq(proxy)
     end


### PR DESCRIPTION
This allows the install to retry on subsequent attempts if it fails