### PR TITLE
after chocolatey 0.10.0 release automated deploy fails

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,5 @@
 default['chocolatey']['upgrade'] = true
+default['chocolatey']['allow_empty_checksums'] = true
 
 # Chocolatey install.ps1 env vars. See https://chocolatey.org/install.ps1
 default['chocolatey']['install_vars'].tap do |env|

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -84,6 +84,7 @@ def cmd_args
   output = ''
   output += " -source #{@current_resource.source}" if @current_resource.source
   output += " -ia '#{@current_resource.args}'" unless @current_resource.args.to_s.empty?
+  output += ' --allow-empty-checksums' if node['chocolatey']['allow_empty_checksums']
   @current_resource.options.each do |k, v|
     output += " -#{k}"
     output += " #{v}" if v


### PR DESCRIPTION
after upgrade to chocolatey 0.10.0 packages with no checksums will ask
for confirmation, which of course breaks automated deployment.
to work around the issue introduce an attribute switched on by default
to pass `--allow-empty-checksums` to choco executable. later when most
of packages will be updated we can switch off this by default.
more info here: https://github.com/chocolatey/choco/issues/910