### PR TITLE
Loosen windows-cookbook restriction

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -11,4 +11,4 @@ issues_url 'https://github.com/chocolatey/chocolatey-cookbook/issues' if defined
 
 supports 'windows'
 
-depends 'windows', '~> 1.38'
+depends 'windows', '>= 1.38'


### PR DESCRIPTION
Because of the mish-mash of versions and fixes in the Windows cookbook, we should depend only on a minimal version.

For example, I'm using Chef 12.latest and I need to use Windows Cookbook 2.0.2, but can't because chocolatey is pinning it to the latest 1.44.x version, which breaks a bunch of other cookbooks.  *sigh*