### PR TITLE
Enable TLS1.2 and TLS1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: ruby
 bundler_args: --without integration
 rvm:
-  - 2.2
+  - 2.2.6
 script: bundle exec rake
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: ruby
 bundler_args: --without integration
 rvm:
-  - 2.1
+  - 2.2
 script: bundle exec rake
 
 branches:

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
-gem 'rake', '~> 10.4'
 gem 'berkshelf', '~> 4.0'
+gem 'rake', '~> 10.4'
 gem 'stove', '~> 3.2'
 
 group :test do
@@ -11,8 +11,8 @@ group :test do
 end
 
 group :integration do
-  gem 'kitchen-vagrant', '~> 0.19'
   gem 'kitchen-inspec', '~> 0.15'
+  gem 'kitchen-vagrant', '~> 0.19'
   gem 'test-kitchen', '~> 1.12'
   gem 'winrm-fs', '~> 1.0'
 end

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ environment:
   SSL_CERT_FILE: c:\projects\chocolatey-cookbook\certs.pem
 
   matrix:
-    - ruby_version: "21"
+    - ruby_version: "22"
 
 clone_folder: c:\projects\chocolatey-cookbook
 clone_depth: 1

--- a/templates/default/InstallChocolatey.ps1.erb
+++ b/templates/default/InstallChocolatey.ps1.erb
@@ -47,6 +47,16 @@ $tempDir = Join-Path $chocTempDir "chocInstall"
 if (![System.IO.Directory]::Exists($tempDir)) {[System.IO.Directory]::CreateDirectory($tempDir)}
 $file = Join-Path $tempDir "chocolatey.zip"
 
+try {
+  # This should work in .NET 4 where .NET 4.5 is installed as an inplace upgrade
+  # Enable TLS1.2 (3072)
+  [System.Net.ServicePointManager]::SecurityProtocol |= 3072
+  # Enable TLS1.1 (768)
+  [System.Net.ServicePointManager]::SecurityProtocol |= 768
+} catch {
+  Write-Warning "Unable to set PowerShell to use TLS 1.2 and TLS 1.1 due to old .NET Framework installed. Please upgrade to at least .NET Framework 4.5 and PowerShell v3 for this to work appropriately."
+}
+
 function Download-File {
 param (
   [string]$url,


### PR DESCRIPTION
This will prevent this error:

    The request was aborted: Could not create SSL/TLS secure channel.

I spent about 4 1/2 hours digging through powershell, windows, etc. to figure this out...

It closes #109.

Note the ServicePointManager is per-process and will not impact anything else outside this `.ps1` script.