### PR TITLE
This fixes the CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: ruby
 bundler_args: --without integration
 rvm:
-  - 2.2
+  - 2.2.6
 script: bundle exec rake
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: ruby
 bundler_args: --without integration
 rvm:
-  - 2.1
+  - 2.2
 script: bundle exec rake
 
 branches:

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
-gem 'rake', '~> 10.4'
 gem 'berkshelf', '~> 4.0'
+gem 'rake', '~> 10.4'
 gem 'stove', '~> 3.2'
 
 group :test do
@@ -11,8 +11,8 @@ group :test do
 end
 
 group :integration do
-  gem 'kitchen-vagrant', '~> 0.19'
   gem 'kitchen-inspec', '~> 0.15'
+  gem 'kitchen-vagrant', '~> 0.19'
   gem 'test-kitchen', '~> 1.12'
   gem 'winrm-fs', '~> 1.0'
 end

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ environment:
   SSL_CERT_FILE: c:\projects\chocolatey-cookbook\certs.pem
 
   matrix:
-    - ruby_version: "21"
+    - ruby_version: "22"
 
 clone_folder: c:\projects\chocolatey-cookbook
 clone_depth: 1


### PR DESCRIPTION
This fixes the Travis and Appveyor CI tests.  The main problem
seemed to be that it needed a newer version of Ruby (2.2.2+).

I set the Ruby version to 2.2.6 for Travis and Appveyor already
picks the latest version of 2.2.