### PR TITLE
Fixed ChefSpec/Fauxhai warning

### DIFF
--- a/spec/matcher_spec.rb
+++ b/spec/matcher_spec.rb
@@ -3,7 +3,9 @@ require 'chefspec/berkshelf'
 
 RSpec.describe 'chocolatey_specs::default' do
   let(:chef_run) do
-    ChefSpec::SoloRunner.converge(described_recipe)
+    ChefSpec::SoloRunner.new(
+      platform: 'windows', version: '2012R2'
+    ).converge(described_recipe)
   end
 
   it 'installs a package' do


### PR DESCRIPTION
The warning said in the future that this would be fatal:

    WARNING: you must specify a platform and platform_version to your ChefSpec Runner and/or Fauxhai constructor, in the future omitting these will become a hard error