### PR TITLE
pin to chef 12

### DIFF
--- a/.kitchen.appveyor.yml
+++ b/.kitchen.appveyor.yml
@@ -9,6 +9,7 @@ driver:
 
 provisioner:
   name: chef_zero
+  require_chef_omnibus: 12.19.36
 
 platforms:
 - name: windows-2012R2


### PR DESCRIPTION
Clearly we want to support chef 13. However that will require rewriting the lwrp and this along with #116 should get this green for now.

Signed-off-by: Matt Wrock <matt@mattwrock.com>