### PR TITLE
fixes #118 and rename conflicting env_path method

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -31,7 +31,7 @@ module Chocolatey
     end
 
     # combine the local path with the user and machine paths
-    def env_path(local_path)
+    def environment_path(local_path)
       machine  = env_var('PATH', 'MACHINE').split(';')
       user     = env_var('PATH', 'USER').split(';')
       local    = local_path.split(';')

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -54,7 +54,7 @@ end
 
 def adjust_path(name)
   ruby_block "track-path-#{name}" do
-    block { ENV['PATH'] = env_path(ENV['PATH']) }
+    block { ENV['PATH'] = environment_path(ENV['PATH']) }
   end
 end
 


### PR DESCRIPTION
Addresses an issue in chef 13 where our helper method conflicts with a method in chef