### PR TITLE
add a chef 13 test on appveyor

### DIFF
--- a/.kitchen.appveyor.yml
+++ b/.kitchen.appveyor.yml
@@ -2,24 +2,33 @@
 driver:
   name: proxy
   host: localhost
-  reset_command: "exit 0"
+  reset_command: "del $env:ChocolateyInstall -Recurse -Force"
   port: 5985
   username: <%= ENV["machine_user"] %>
   password: <%= ENV["machine_pass"] %>
 
 provisioner:
   name: chef_zero
-  require_chef_omnibus: 12.19.36
 
 platforms:
 - name: windows-2012R2
 
 suites:
-  - name: default
+  - name: chef_12
+    provisioner:
+      require_chef_omnibus: 12.19.36
     run_list:
       - recipe[chocolatey::default]
       - recipe[chocolatey_test::default]
     attributes:
       chocolatey:
         install_vars:
-          chocolateyVersion: 0.9.10.3
+          chocolateyVersion: 0.10.5
+
+  - name: chef_latest
+    run_list:
+      - recipe[chocolatey::default]
+    attributes:
+      chocolatey:
+        install_vars:
+          chocolateyVersion: 0.10.5

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -14,11 +14,13 @@ verifier:
   name: inspec
 
 suites:
-  - name: default
+  - name: chef_12
+    provisioner:
+      require_chef_omnibus: 12.19.36
     run_list:
       - recipe[chocolatey::default]
       - recipe[chocolatey_test::default]
     attributes:
       chocolatey:
         install_vars:
-          chocolateyVersion: 0.9.10.3
+          chocolateyVersion: 0.10.5

--- a/test/integration/chef_12/default_spec.rb
+++ b/test/integration/chef_12/default_spec.rb
@@ -16,7 +16,7 @@ describe command("#{choco_exe} list -l git.install") do
 end
 
 describe command("#{choco_exe} --version") do
-  its(:stdout) { should eq("0.9.10.3\r\n") }
+  its(:stdout) { should eq("0.10.5\r\n") }
 end
 
 describe file(chocolatey_nupkg) do

--- a/test/integration/chef_latest/default_spec.rb
+++ b/test/integration/chef_latest/default_spec.rb
@@ -1,0 +1,20 @@
+choco_exe = File.join(ENV['ProgramData'], 'chocolatey', 'bin', 'choco.exe')
+chocolatey_nupkg = File.join(
+  ENV['ProgramData'], 'chocolatey', 'lib', 'chocolatey', 'chocolatey.nupkg'
+)
+
+describe command(choco_exe) do
+  its(:stdout) { should match(/Chocolatey/) }
+end
+
+describe command("#{choco_exe} list -l chocolatey") do
+  its(:stdout) { should match(/[1-9] packages installed\./) }
+end
+
+describe command("#{choco_exe} --version") do
+  its(:stdout) { should eq("0.10.5\r\n") }
+end
+
+describe file(chocolatey_nupkg) do
+  it { should exist }
+end


### PR DESCRIPTION
Adds a chef 13 test on appveyor that just tests the installer. We dont care about supporting the resource on chef 13 since we are guaranteed that version will have a chocolatey recource in chef.

Signed-off-by: Matt Wrock <matt@mattwrock.com>
