### PR TITLE
enforce lf line endings and bring in needed gems in a clean environment

### DIFF
--- a/.kitchen.appveyor.yml
+++ b/.kitchen.appveyor.yml
@@ -2,7 +2,7 @@
 driver:
   name: proxy
   host: localhost
-  reset_command: "del $env:ChocolateyInstall -Recurse -Force"
+  reset_command: "if(Test-Path $env:ChocolateyInstall) { del $env:ChocolateyInstall -Recurse -Force }"
   port: 5985
   username: <%= ENV["machine_user"] %>
   password: <%= ENV["machine_pass"] %>

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+Style/EndOfLine:
+  EnforcedStyle: lf

--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,7 @@
 
 source 'https://rubygems.org'
 
+gem 'cookstyle'
+gem 'foodcritic'
+gem 'rake'
 gem 'stove'


### PR DESCRIPTION
this should fix the rubocop errors we are seeing as mentioned in #125 