### PR TITLE
Add source(s) resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Attribute                                     | Description                     
 # Resources
 
 - [chocolatey](#chocolatey)
+- [chocolatey_source](#chocolatey_source)
+- [chocolatey_sources](#chocolatey_sources)
 
 ## chocolatey
 
@@ -59,6 +61,32 @@ Attribute                                     | Description                     
 - version: The version of the package to use.
 - args: arguments to the installation.
 - options: Hash of additional options to be sent to `choco.exe`
+
+## chocolatey_source
+
+Configures/updates a named chocolatey source
+
+### Actions
+
+- add: Add/update the given source
+- remove: Remove the given source
+
+### Resource Properties
+
+- name: Name of the source to add/remove (default name)
+- source: The URI of the source (ignored when removing)
+
+## chocolatey_sources
+
+Manages the set of chocolatey sources for a machine
+
+### Actions
+
+- manage: Add missing sources, and remove superfluous ones
+
+### Resource Properties
+
+- sources: A hash of source Name => URI pairs
 
 # Examples
 
@@ -87,6 +115,19 @@ end
 chocolatey "some_private_secure_package" do
   source "https://some.proget/feed"
   options ({'u' => 'username', 'p' => 'password'})
+end
+
+chocolatey_source 'my_private_feed' do
+  source 'https://my.private/feed'
+end
+
+sources = {
+  'my_private_feed' => 'https://my.private/feed',
+  'chocolatey' => 'https://chocolatey.org/api/v2/'
+}
+
+chocolatey_sources 'Manage Choco Sources' do
+  source 'https://my.private/feed'
 end
 
 chocolatey 'DotNet4.5'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -20,6 +20,10 @@ module Chocolatey
       File.join(chocolatey_install, 'lib', 'chocolatey')
     end
 
+    def chocolatey_config_file
+      File.join(chocolatey_install, 'config', 'chocolatey.config')
+    end
+
     # Check if Chocolatey is installed
     def chocolatey_installed?
       return @is_chocolatey_installed if @is_chocolatey_installed

--- a/resources/source.rb
+++ b/resources/source.rb
@@ -1,0 +1,65 @@
+#
+# Author:: Blair Hamilton (bhamilton@draftkings.com>)
+# Author:: Jonathan Morley (morley.jonathan@gmail.com>)
+# Cookbook Name:: chocolatey
+# Resource:: source
+#
+# Copyright 2015, Blair Hamilton
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require 'chef/mixin/shell_out'
+include Chef::Mixin::ShellOut
+
+include ::Chocolatey::Helpers
+
+property :name, kind_of: String, name_attribute: true
+property :source, kind_of: String
+
+default_action :add
+
+load_current_value do
+  require 'nokogiri'
+
+  current_value_does_not_exist! unless ::File.exist?(chocolatey_config_file)
+
+  config = ::File.open(chocolatey_config_file) { |f| Nokogiri::XML(f) }
+
+  config_source = config.xpath("/chocolatey/sources/source[@id='#{name}']").first
+  current_value_does_not_exist! if config_source.nil?
+
+  source config_source.attribute('value').text
+end
+
+action :add do
+  converge_if_changed :source do
+    choco_cmd = 'choco source add'
+    choco_cmd << " --name \"#{new_resource.name}\"" if new_resource.name
+    choco_cmd << " --source \"#{new_resource.source}\"" if new_resource.source
+
+    execute 'add choco source' do
+      action :run
+      command choco_cmd
+    end
+  end
+end
+
+action :remove do
+  choco_cmd = 'choco source remove'
+  choco_cmd << " --name \"#{new_resource.name}\"" if new_resource.name
+
+  execute 'remove choco source' do
+    action :run
+    command choco_cmd
+  end
+end

--- a/resources/sources.rb
+++ b/resources/sources.rb
@@ -1,0 +1,63 @@
+#
+# Author:: George Vanburgh (gvanburgh@bloomberg.net)
+# Cookbook Name:: chocolatey
+# Resource:: sources
+#
+# Copyright 2017, Bloomberg L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include ::Chocolatey::Helpers
+
+property :sources, kind_of: Hash
+
+default_action :manage
+
+load_current_value do
+  require 'nokogiri'
+
+  current_value_does_not_exist! unless ::File.exist?(chocolatey_config_file)
+
+  config = ::File.open(chocolatey_config_file) { |f| Nokogiri::XML(f) }
+
+  sources_config = config.xpath('/chocolatey/sources/source')
+  configured_sources = Hash[sources_config.map { |s| [s['id'], s['value']] }]
+
+  current_value_does_not_exist! if configured_sources.nil?
+
+  sources configured_sources
+end
+
+action :manage do
+  converge_if_changed :sources do
+    missing_sources = (new_resource.sources.to_a - current_resource.sources.to_a).to_h
+    superfluous_sources = (current_resource.sources.to_a - new_resource.sources.to_a).to_h
+
+    # No point in removing a source if we're about to modify it
+    superfluous_sources.delete_if { |key, _| missing_sources.key?(key) }
+
+    superfluous_sources.each do |id_to_remove, _|
+      chocolatey_source id_to_remove do
+        action :remove
+      end
+    end
+
+    missing_sources.each do |id_to_update, source|
+      chocolatey_source id_to_update do
+        action :add
+        source source
+      end
+    end
+  end
+end

--- a/test/cookbooks/chocolatey_test/recipes/default.rb
+++ b/test/cookbooks/chocolatey_test/recipes/default.rb
@@ -7,3 +7,12 @@ git File.join(ENV['TEMP'], 'chocolatey-cookbook') do
   revision 'master'
   action :sync
 end
+
+test_sources = {
+  'test_source' => 'http://test.com/api/',
+  'test_source2' => '\\\\testing\\folder',
+}
+
+chocolatey_sources 'chocolatey.sources' do
+  sources test_sources
+end

--- a/test/integration/chef_12/default_spec.rb
+++ b/test/integration/chef_12/default_spec.rb
@@ -26,3 +26,9 @@ end
 describe file(File.join('$env:temp', 'chocolatey-cookbook', 'metadata.rb')) do
   it { should exist }
 end
+
+describe command("#{choco_exe} sources list") do
+  its(:stdout) { should match(%r{test_source - http://test.com/api/}) }
+  its(:stdout) { should match(/test_source2 - \\\\testing\\folder/) }
+  its(:stdout) { should_not match(%r{chocolatey - https://chocolatey.org/api/v2/}) }
+end

--- a/test/integration/chef_latest/default_spec.rb
+++ b/test/integration/chef_latest/default_spec.rb
@@ -18,3 +18,9 @@ end
 describe file(chocolatey_nupkg) do
   it { should exist }
 end
+
+describe command("#{choco_exe} sources list") do
+  its(:stdout) { should match(%r{test_source - http://test.com/api/}) }
+  its(:stdout) { should match(/test_source2 - \\\\testing\\folder/) }
+  its(:stdout) { should_not match(%r{chocolatey - https://chocolatey.org/api/v2/}) }
+end


### PR DESCRIPTION
### Description
Add two new resources, `chocolatey_source` and `chocolatey_sources`

The `chocolatey_source` resource allows for the addition, deletion or updating of a single chocolatey source

The `chocolatey_sources` resource wraps this, and will manage all the sources on a machine, by removing sources that shouldn't exist, and adding those that are missing

Could be extended to add support for disabling sources/adding sources which require authentication - but I thought I'd get the basic functionality down first.

### Issues Resolved

Resolves #84, builds on work done by @jonathanmorley in #101 

### Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
